### PR TITLE
Bump advertised version to 0.9.4

### DIFF
--- a/project/Constants.scala
+++ b/project/Constants.scala
@@ -1,4 +1,4 @@
 package scalatags
 object Constants{
-  val version = "0.8.1"
+  val version = "0.9.4"
 }


### PR DESCRIPTION
Is the website at https://com-lihaoyi.github.io/scalatags/ generated from this repo? by looking at [`Readme.scalatex`](https://github.com/com-lihaoyi/scalatags/blob/6f934f0d611ee4d3b59f69fa2081f5b28f24ebe3/readme/Readme.scalatex) it seems it does, how come the advertised version on the site is `0.8.2` if this value right here points to `0.8.1`, in any case shouldn't this be updated to latest `0.9.4`?