### PR TITLE
fix: mima issues in build definition

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -15,12 +15,22 @@ val scala2Versions = scalaVersions.filter(_.startsWith("2."))
 val scalaJSVersions = scalaVersions.map((_, "1.10.1"))
 val scalaNativeVersions = scalaVersions.map((_, "0.4.5"))
 
-trait ScalatagsPublishModule extends PublishModule with Mima {
+trait MimaCheck extends Mima {
+  def mimaPreviousVersions = Seq("0.11.0", "0.11.1")
+}
+
+trait ScalatagsPublishModule extends PublishModule with MimaCheck {
   def artifactName = "scalatags"
+
 
   def publishVersion = VcsVersion.vcsState().format()
 
-  def mimaPreviousVersions = Seq("0.11.0")
+  def crossScalaVersion: String
+
+  // Temporary until the next version of Mima gets released with
+  // https://github.com/lightbend/mima/issues/693 included in the release.
+  def mimaPreviousArtifacts =
+    if(isScala3(crossScalaVersion)) Agg.empty[Dep] else super.mimaPreviousArtifacts()
 
   def pomSettings = PomSettings(
     description = artifactName(),


### PR DESCRIPTION
There were two Mima issues that popped up after https://github.com/com-lihaoyi/scalatags/commit/1724d9b4f219088103b69e43ff3445f7f2f4633d

1. ~It looks like we were hitting on
   lightbend/mima#693 which has been fixed,
   but not released yet. Therefore I bumped down to 3.1.0 to make Mima
   happy for now. After the next release we can update Mima and then
   update the Scala version as well.~
2. There is no `scalatags_native0.4_3` published yet, ~so the easiest fix
   for now was to just remove Mima from the native stuff. If there is a
   cleaner way to do this, let me know.~ So this removes the Mima check from the native and Scala 3 combo.

EDIT: Just turn of Mima for Scala 3 for now.