### PR TITLE
Remove UnitFrag (closes #249)

### DIFF
--- a/scalatags/js/src/scalatags/JsDom.scala
+++ b/scalatags/js/src/scalatags/JsDom.scala
@@ -102,7 +102,6 @@ object JsDom
     protected[this] implicit def stringAttrX = new GenericAttr[String]
     protected[this] implicit def stringStyleX = new GenericStyle[String]
     protected[this] implicit def stringPixelStyleX = new GenericPixelStyle[String](stringStyleX)
-    implicit def UnitFrag(u: Unit): JsDom.StringFrag = new JsDom.StringFrag("")
     def makeAbstractTypedTag[T <: dom.Element](tag: String, void: Boolean, namespaceConfig: Namespace): TypedTag[T] = {
       TypedTag(tag, Nil, void, namespaceConfig)
     }

--- a/scalatags/src/scalatags/Text.scala
+++ b/scalatags/src/scalatags/Text.scala
@@ -52,7 +52,6 @@ object Text
     protected[this] implicit def stringAttrX = new GenericAttr[String]
     protected[this] implicit def stringStyleX = new GenericStyle[String]
     protected[this] implicit def stringPixelStyleX = new GenericPixelStyle[String](stringStyleX)
-    implicit def UnitFrag(u: Unit) = new Text.StringFrag("")
     def makeAbstractTypedTag[T <: String](tag: String, void: Boolean, namespaceConfig: Namespace): TypedTag[T] = {
       TypedTag(tag, Nil, void)
     }

--- a/scalatags/src/scalatags/VirtualDom.scala
+++ b/scalatags/src/scalatags/VirtualDom.scala
@@ -98,7 +98,6 @@ trait VirtualDom[Output <: FragT, FragT]
     protected[this] implicit def stringAttrX = new GenericAttr[String]
     protected[this] implicit def stringStyleX = new GenericStyle[String]
     protected[this] implicit def stringPixelStyleX = new GenericPixelStyle[String](stringStyleX)
-    implicit def UnitFrag(u: Unit): VirtualDom.this.StringFrag = new VirtualDom.this.StringFrag("")
     def makeAbstractTypedTag[T <: Output](tag: String, void: Boolean, namespaceConfig: Namespace): TypedTag[T] = {
       TypedTag(tag, Nil, void, namespaceConfig)
     }

--- a/scalatags/src/scalatags/generic/Util.scala
+++ b/scalatags/src/scalatags/generic/Util.scala
@@ -106,9 +106,4 @@ trait LowPriUtil[Builder, Output <: FragT, FragT]{
    * Renders an Seq of [[FragT]] into a single [[FragT]]
    */
   implicit def ArrayFrag[A](xs: Array[A])(implicit ev: A => Frag[Builder, FragT]): Frag[Builder, FragT] = SeqFrag[A](xs.toSeq)
-
-  /**
-   * Lets you put Unit into a scalatags tree, as a no-op.
-   */
-  implicit def UnitFrag(u: Unit): Frag[Builder, FragT]
 }

--- a/scalatags/test/src/scalatags/generic/BasicTests.scala
+++ b/scalatags/test/src/scalatags/generic/BasicTests.scala
@@ -100,8 +100,7 @@ class BasicTests[Builder, Output <: FragT, FragT](omg: Bundle[Builder, Output, F
           None: Option[String],
           h1("Hello"),
           Array(1, 2, 3),
-          strArr,
-          ()
+          strArr
         ),
         """<div>lol1<h1>Hello</h1>123hello</div>"""
       )


### PR DESCRIPTION
Prevents accidentally using if without else in Scala 3, which now always evaluates to `()`.