### PR TITLE
fix: ensure defs are captured in Scala 3 stylesheets

### DIFF
--- a/readme/Readme.scalatex
+++ b/readme/Readme.scalatex
@@ -706,7 +706,7 @@
     @p
       You can then access @hl.scala{Simple.styleSheetText} in order to do things with the generated stylesheet text. Exactly what you want to do is up to you: In Scala-JVM you will likely want to save it to a file (to be served later) or inlined into some HTML fragment, while in Scala.js you may insert it into the page directly via a @hl.scala{style} tag.
     @p
-      Only @hl.scala{cls}s defined on @hl.scala{trait Simple} are gathered up as part of the generated stylesheet. By default, the name of each class is constructed via the names @hl.scala{$pkg-$class-$val}. You can override @hl.scala{customSheetName} to replace the @hl.scala{pkg-$class} part with something else.
+      Only @hl.scala{cls}s defined on @hl.scala{trait Simple} are gathered up as part of the generated stylesheet. By default, the name of each class is constructed via the names @hl.scala{$pkg-$class-$val} or @hl.scala{$pkg-$class-$def}. You can override @hl.scala{customSheetName} to replace the @hl.scala{pkg-$class} part with something else.
     @p
       Once the stylesheet is defined, you can then immediately start using styles within your Scalatags fragments, just like any other @hl.scala{Modifier}:
 
@@ -716,7 +716,7 @@
     @hl.ref(cssTests, Seq("htmlFrag", "val expected", ""), "\"\"\"", className = "xml")
 
     @p
-      By default, Scalatag's @hl.scala{StyleSheet}s have no cascading: you only can define styles for a single class (and it's pseudo-selectors) at a single time. If you want to define styles for multiple tags without a larger HTML fragment, you should define multiple classes. The fact that Scalatag's @hl.scala{cls} definitions are just normal @hl.scala{val}s makes managing these classes very easy: you can use standard IDE's or tools to jump-to-definitions, auto-rename them, etc.. Many common mistakes in CSS, such as accidentally mis-spelling a class-name or botching a renaming, become compilation errors.
+      By default, Scalatag's @hl.scala{StyleSheet}s have no cascading: you only can define styles for a single class (and it's pseudo-selectors) at a single time. If you want to define styles for multiple tags without a larger HTML fragment, you should define multiple classes. The fact that Scalatag's @hl.scala{cls} definitions are just normal @hl.scala{val}s or @hl.scala{def}s makes managing these classes very easy: you can use standard IDE's or tools to jump-to-definitions, auto-rename them, etc.. Many common mistakes in CSS, such as accidentally mis-spelling a class-name or botching a renaming, become compilation errors.
     @p
       Since Scalatags @hl.scala{StyleSheet}s are just Scala, you can feel free to use normal Scala techniques (constants, functions, traits, etc.) to DRY up your code without having to learn any special Scalatags-specific mechanisms.
 

--- a/scalatags/src-3/scalatags/stylesheet/SourceClasses.scala
+++ b/scalatags/src-3/scalatags/stylesheet/SourceClasses.scala
@@ -3,17 +3,21 @@ package scalatags.stylesheet
 import scala.quoted.*
 
 class SourceClasses[T](val value: T => Seq[Cls])
-object SourceClasses {
+object SourceClasses:
   inline implicit def apply[T]: SourceClasses[T] = ${ manglerImpl[T] }
 
-  def manglerImpl[T: Type](using Quotes): Expr[SourceClasses[T]] = {
+  def manglerImpl[T: Type](using Quotes): Expr[SourceClasses[T]] =
     '{ new SourceClasses[T]((t: T) => ${ Expr.ofSeq(terms('t)) }) }
-  }
 
-  private def terms[T: Type](t: Expr[T])(using ctx: Quotes): Seq[Expr[Cls]] = {
+  private def terms[T: Type](t: Expr[T])(using ctx: Quotes): Seq[Expr[Cls]] =
     import ctx.reflect._
     val valdefs = TypeRepr.of[T].typeSymbol.declaredFields.map(_.tree.asInstanceOf[ValDef])
-    val clsesOnly: Seq[ValDef] = valdefs.filter(_.tpt.tpe =:= TypeRepr.of[Cls])
-    clsesOnly.map(valdef => t.asTerm.select(valdef.symbol).asExprOf[Cls])
-  }
-}
+    val defdefs = TypeRepr.of[T].typeSymbol.declaredMethods.map(_.tree.asInstanceOf[DefDef])
+
+    val valclsesOnly: Seq[ValDef] = valdefs.filter(_.tpt.tpe =:= TypeRepr.of[Cls])
+    val defclsesOnly: Seq[DefDef] = defdefs.filter(_.returnTpt.tpe =:= TypeRepr.of[Cls])
+
+    val defClsExpressions = defclsesOnly.map(defdef => t.asTerm.select(defdef.symbol).asExprOf[Cls])
+    val valClsExpressions = valclsesOnly.map(valdef => t.asTerm.select(valdef.symbol).asExprOf[Cls])
+
+    defClsExpressions ++ valClsExpressions

--- a/scalatags/test/src/scalatags/generic/StyleSheetTests.scala
+++ b/scalatags/test/src/scalatags/generic/StyleSheetTests.scala
@@ -83,6 +83,19 @@ abstract class StyleSheetTests[Builder, Output <: FragT, FragT]
 
   }
 
+  object Defs extends CascadingStyleSheet{
+    initStyleSheet()
+
+    def x = cls(
+      backgroundColor := "red",
+      height := 125
+    )
+
+    def y = cls.hover(
+      opacity := 0.5
+    )
+  }
+
 
   def check(txt: String, expected: String) = {
     // augmentString = work around scala/bug#11125 on JDK 11
@@ -163,6 +176,20 @@ abstract class StyleSheetTests[Builder, Output <: FragT, FragT]
             height: 125px;
           }
           .CuStOm-y:hover{
+            opacity: 0.5;
+          }
+         """
+      )
+    }
+    test("defs"){
+      check(
+        Defs.styleSheetText,
+        s"""
+          .$pkg-Defs-x{
+            background-color: red;
+            height: 125px;
+          }
+          .$pkg-Defs-y:hover{
             opacity: 0.5;
           }
          """


### PR DESCRIPTION
In Scala 2 the macro for SourceClasses captures both `def`s and `val`s where currently the Scala 3 implementation will only capture `val`s. This change updates the Scala 3 `SourceClasses` to ensure parity with the Scala 2 implementation making sure to also capture `def` classes.

Fixes #257