### PR TITLE
Make text.Frag extend geny.Writable

### DIFF
--- a/scalatags/src/scalatags/text/Builder.scala
+++ b/scalatags/src/scalatags/text/Builder.scala
@@ -144,7 +144,8 @@ object Builder{
   }
 }
 
-trait Frag extends generic.Frag[Builder, String] {
+trait Frag extends generic.Frag[Builder, String] with geny.Writable {
+  override def httpContentType = Some("text/html")
   def writeTo(strb: java.io.Writer): Unit
   def writeBytesTo(out: java.io.OutputStream): Unit = {
     val w = new java.io.OutputStreamWriter(out, java.nio.charset.StandardCharsets.UTF_8)


### PR DESCRIPTION
This will allow the result of `frag()` to be converted to a `geny.Writable`.

Currently only `scalatags.Text.TypeTag` extends it, but technically `text.Frag` could also extend it. So we're in a strange situation, where:

```
scalatags.Text.all.div(): geny.Writable // works
scalatags.Text.all.frag(): geny.Writable // fails
```

This would fix that.